### PR TITLE
feat: search word on right-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ---
 
 ## ✨ Features
-- Highlight any word on a webpage
-- Right-click → **Search meaning of "<word>"**
+- Highlight any word on a webpage (optional)
+- Simply right-click a word to search its meaning
 - Opens a new Google tab with `meaning of <word>`
 - Minimal, fast, no extra clutter
 
@@ -25,7 +25,7 @@
 3. Open Chrome and navigate to `chrome://extensions`.
 4. Enable **Developer mode** (toggle in top-right).
 5. Click **Load unpacked** and select the extracted folder.
-6. Done! Now highlight any word, right-click, and search its meaning instantly.
+6. Done! Now highlight or just right-click any word to search its meaning instantly.
 
 ---
 

--- a/background.js
+++ b/background.js
@@ -18,3 +18,9 @@ chrome.contextMenus.onClicked.addListener((info) => {
     openMeaningSearch(info.selectionText);
   }
 });
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message && message.action === "openMeaningSearch" && message.text) {
+    openMeaningSearch(message.text);
+  }
+});

--- a/hover-search.js
+++ b/hover-search.js
@@ -1,0 +1,25 @@
+// Listens for right-clicks on words to trigger a meaning search
+// without requiring text selection.
+document.addEventListener('contextmenu', (event) => {
+  const sel = window.getSelection();
+  if (sel && sel.toString().trim()) {
+    // Let the existing selection handler take over.
+    return;
+  }
+
+  const range = document.caretRangeFromPoint?.(event.clientX, event.clientY);
+  if (!range || !range.startContainer || range.startContainer.nodeType !== Node.TEXT_NODE) {
+    return;
+  }
+
+  const text = range.startContainer.textContent;
+  const offset = range.startOffset;
+  const before = text.slice(0, offset).match(/\w+$/);
+  const after = text.slice(offset).match(/^\w+/);
+  const word = ((before ? before[0] : '') + (after ? after[0] : '')).trim();
+
+  if (word) {
+    chrome.runtime.sendMessage({ action: 'openMeaningSearch', text: word });
+    event.preventDefault();
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,13 @@
   "description": "Right-click selected text to search 'meaning of <text>' on Google.",
   "permissions": ["contextMenus"],
   "background": { "service_worker": "background.js" },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["hover-search.js"],
+      "run_at": "document_end"
+    }
+  ],
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
## Summary
- Allow right-clicking a word (without selecting) to search its meaning
- Wire background service worker to handle content-script messages
- Document the new right-click behavior

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c701fe16208331ae429741ca00709e